### PR TITLE
chore: Trigger releases manually

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,16 +1,13 @@
 ---
 name: "\U0001F41B Bug Report"
 about: Report a bug
-title: "(module name): short issue description"
+title: "short issue description"
 labels: bug, needs-triage
 ---
 
 <!--
 description of the bug:
 -->
-
-
-
 
 ### Reproduction Steps
 
@@ -30,7 +27,6 @@ What were you trying to achieve by performing the steps above?
 What is the unexpected behavior you were seeing? If you got an error, paste it here.
 -->
 
-
 ### Environment
 
   - **CDK CLI Version  :**
@@ -42,9 +38,6 @@ What is the unexpected behavior you were seeing? If you got an error, paste it h
 ### Other
 
 <!-- e.g. detailed explanation, stacktraces, related issues, suggestions on how to fix, links for us to have context, eg. associated pull-request, stackoverflow, slack, etc -->
-
-
-
 
 --- 
 

--- a/.github/ISSUE_TEMPLATE/doc.md
+++ b/.github/ISSUE_TEMPLATE/doc.md
@@ -1,7 +1,7 @@
 ---
 name: "📕 Documentation Issue"
 about: Issue in the reference documentation or developer guide
-title: "(module name): short issue description"
+title: "short issue description"
 labels: feature-request, documentation, needs-triage
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,31 +1,19 @@
 ---
 name: "\U0001F680 Feature Request"
 about: Request a new feature
-title: "(module name): short issue description"
+title: "short issue description"
 labels: feature-request, needs-triage
 ---
 
 <!-- short description of the feature you are proposing: -->
 
-
-
-
-
 ### Use Case
 
 <!-- why do you need this feature? -->
 
-
-
-
-
 ### Proposed Solution
 
 <!-- Please include prototype/workaround/sketch/reference implementation: -->
-
-
-
-
 
 ### Other
 
@@ -33,10 +21,6 @@ labels: feature-request, needs-triage
 e.g. detailed explanation, stacktraces, related issues, suggestions on how to fix, 
 links for us to have context, eg. associated pull-request, stackoverflow, slack, etc
 -->
-
-
-
-
 
 * [ ] :wave: I may be able to implement this feature request
 * [ ] :warning: This feature might incur a breaking change

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,6 @@
 
 name: Release
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch: {}
 jobs:
   build:

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -98,8 +98,8 @@ const project = new AwsCdkConstructLibrary({
   // pullRequestTemplateContents: undefined,                                   /* The contents of the pull request template. */
   // rebuildBot: undefined,                                                    /* Installs a GitHub workflow which is triggered when the comment "@projen rebuild" is added to a pull request. */
   // rebuildBotCommand: 'rebuild',                                             /* The pull request bot command to use in order to trigger a rebuild and commit of the contents of the branch. */
-  // releaseBranches: [ 'main' ],                                              /* Branches which trigger a release. */
-  // releaseEveryCommit: true,                                                 /* Automatically release new versions every commit to one of branches in `releaseBranches`. */
+  releaseBranches: [], /* Branches which trigger a release. */
+  releaseEveryCommit: false, /* Automatically release new versions every commit to one of branches in `releaseBranches`. */
   // releaseSchedule: undefined,                                               /* CRON schedule to trigger new releases. */
   releaseToNpm: true, /* Automatically release to npm when new versions are introduced. */
   // releaseWorkflow: undefined,                                               /* Define a GitHub workflow for releasing from "main" when new versions are bumped. */


### PR DESCRIPTION
Instead of releasing on every merge to `main` you now have to start the release workflow by hand.