### PR TITLE
feat: Harden NodeGroupRole by denying VPC actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ __super-eks__ solves this problem by making a few choices for you as outlined be
 - :white_check_mark: Forwarding logs to CloudWatch Logs with [fluent-bit](https://github.com/aws/aws-for-fluent-bit)
 - :white_check_mark: Ingress management with the [AWS Load Balancer Controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller)
 - :white_check_mark: Isolated node groups, one for the shipped components, the other one for your workloads
+- :white_check_mark: Hardened node setup, deny Nodes Roles from altering the VPC setup.
 
 ### :world_map:	Roadmap
 
-- :hammer_and_wrench: Hardened node setup
 - :hammer_and_wrench: Monitoring with Prometheus and CloudWatch
 - :hammer_and_wrench: Backup solution for cluster recovery
 - :hammer_and_wrench: Authentication/authorization for workloads with Amazon Cognito

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ __super-eks__ solves this problem by making a few choices for you as outlined be
 - :white_check_mark: Forwarding logs to CloudWatch Logs with [fluent-bit](https://github.com/aws/aws-for-fluent-bit)
 - :white_check_mark: Ingress management with the [AWS Load Balancer Controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller)
 - :white_check_mark: Isolated node groups, one for the shipped components, the other one for your workloads
-- :white_check_mark: Hardened node setup, deny Nodes Roles from altering the VPC setup.
+- :white_check_mark: Hardened node setup, deny nodes altering the VPC setup.
+- :white_check_mark: Default to [managed cluster add-ons](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html#update-cluster-add-ons) where possible. 
 
 ### :world_map:	Roadmap
 

--- a/test/constructs/super-eks.test.ts
+++ b/test/constructs/super-eks.test.ts
@@ -1,5 +1,5 @@
 import '@aws-cdk/assert/jest';
-import { ABSENT, arrayWith, ResourcePart, stringLike } from '@aws-cdk/assert';
+import { arrayWith, objectLike, stringLike, ResourcePart, ABSENT } from '@aws-cdk/assert';
 import * as route53 from '@aws-cdk/aws-route53';
 import * as cdk from '@aws-cdk/core';
 
@@ -101,5 +101,25 @@ test('It installs external-dns', () => {
   expect(stack).toHaveResource('Custom::AWSCDK-EKS-HelmChart', {
     Namespace: 'dns',
     Chart: 'external-dns',
+  });
+});
+
+test('It hardens all Nodes', () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, 'Stack', {
+    env: { region: 'eu-central-1', account: '1234567891011' },
+  });
+  // WHEN
+  new SuperEks(stack, 'TestCluster', {
+    hostedZone: route53.HostedZone.fromHostedZoneId(stack, 'HostedZone', '123'),
+  });
+
+  // THEN
+  expect(stack).toHaveResource('AWS::IAM::Policy', {
+    PolicyName: stringLike('*NodeHardeningPolicy*'),
+    Roles: arrayWith(
+      objectLike( { Ref: stringLike('*EksClusterNodegroupSuperEksNodegroupNodeGroupRole*') }),
+      objectLike( { Ref: stringLike('*EksClusterNodegroupDefaultCapacityNodeGroupRole*') }),
+    ),
   });
 });


### PR DESCRIPTION
Theese actions are not necessary, since they are performed by the
managed VPC CNI Addon, which uses its own role via IRSA.
Therefore the Node Roles shouldn't be allowed to perform them.

Fixes #35 