### PR TITLE
fix: add docs to alowed titles

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -25,4 +25,5 @@ jobs:
             feat
             fix
             chore
+            docs
           requireScope: false

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -140,6 +140,18 @@ const project = new AwsCdkConstructLibrary({
       target: 'ES2018',
     },
   },
+  githubOptions: {
+    pullRequestLintOptions: {
+      semanticTitleOptions: {
+        types: [
+          'feat',
+          'fix',
+          'chore',
+          'docs',
+        ],
+      },
+    },
+  },
 });
 
 project.synth();


### PR DESCRIPTION
`docs` is currently not allowed in PR titles. We used this prefix for adding documentation and it is also part of the standard set that is allowed (https://github.com/commitizen/conventional-commit-types/blob/master/index.json). Projen does its own thing, though.
This commit should fix this.