### PR TITLE
fix: Enforce namespace annotations for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ aws secretsmanager create-secret --name hello-service/password --secret-string "
 ```
 
 The service account that will be used by external secrets uses a condition in the IAM policy so that access will be automatically granted.
-To keep the setup secure and sound **have to set namespace annotations** for secrets as described in the
+To keep the setup secure and sound **you have to set namespace annotations** for secrets as described in the
 [original documentation](https://github.com/external-secrets/kubernetes-external-secrets#using-namespace-annotation).
 
 ## :open_book: API documentation

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ aws secretsmanager create-secret --name hello-service/password --secret-string "
 ```
 
 The service account that will be used by external secrets uses a condition in the IAM policy so that access will be automatically granted.
-You can still set namespace restrictions for secrets as described in the original documentation.
+To keep the setup secure and sound **have to set namespace annotations** for secrets as described in the
+[original documentation](https://github.com/external-secrets/kubernetes-external-secrets#using-namespace-annotation).
 
 ## :open_book: API documentation
 

--- a/src/constructs/external-secrets.ts
+++ b/src/constructs/external-secrets.ts
@@ -36,6 +36,7 @@ export class ExternalSecrets extends cdk.Construct {
       values: {
         env: {
           AWS_REGION: cdk.Stack.of(this).region,
+          ENFORCE_NAMESPACE_ANNOTATIONS: true,
         },
         serviceAccount: {
           create: false,

--- a/test/constructs/external-secrets.test.ts
+++ b/test/constructs/external-secrets.test.ts
@@ -39,7 +39,7 @@ describe('external-secrets', () => {
             {
               Ref: 'AWS::Region',
             },
-            '"},"serviceAccount":{"create":false,"name":"external-secrets"},"securityContext":{"runAsNonRoot":true,"fsGroup":65534}}',
+            '","ENFORCE_NAMESPACE_ANNOTATIONS":true},"serviceAccount":{"create":false,"name":"external-secrets"},"securityContext":{"runAsNonRoot":true,"fsGroup":65534}}',
           ],
         ],
       },


### PR DESCRIPTION
Fixes #379 by enforcing an annotation on the namespace to allow reading a secret, basically not allowing default access.